### PR TITLE
Imports & Stack duplications

### DIFF
--- a/ASTNode.h
+++ b/ASTNode.h
@@ -253,14 +253,21 @@ private:
 
 class ASTImport : public ASTNode {
 public:
+    typedef std::list<PycRef<ASTStore> > list_t;
+
     ASTImport(PycRef<ASTNode> name, PycRef<ASTNode> fromlist)
         : ASTNode(NODE_IMPORT), m_name(name), m_fromlist(fromlist) { }
 
     PycRef<ASTNode> name() const { return m_name; }
+    list_t stores() const { return m_stores; }
+    void add_store(PycRef<ASTStore> store) { m_stores.push_back(store); }
+
     PycRef<ASTNode> fromlist() const { return m_fromlist; }
 
 private:
     PycRef<ASTNode> m_name;
+    list_t m_stores;
+
     PycRef<ASTNode> m_fromlist;
 };
 

--- a/ASTree.cpp
+++ b/ASTree.cpp
@@ -527,6 +527,7 @@ PycRef<ASTNode> BuildFromCode(PycRef<PycCode> code, PycModule* mod)
             }
             break;
         case Pyc::IMPORT_FROM_A:
+            stack.push(new ASTName(code->getName(operand)));
             break;
         case Pyc::IMPORT_STAR:
             {
@@ -812,8 +813,10 @@ PycRef<ASTNode> BuildFromCode(PycRef<PycCode> code, PycModule* mod)
         case Pyc::LOAD_ATTR_A:
             {
                 PycRef<ASTNode> name = stack.top();
-                stack.pop();
-                stack.push(new ASTBinary(name, new ASTName(code->getName(operand)), ASTBinary::BIN_ATTR));
+                if (name->type() != ASTNode::NODE_IMPORT) {
+                    stack.pop();
+                    stack.push(new ASTBinary(name, new ASTName(code->getName(operand)), ASTBinary::BIN_ATTR));
+                }
             }
             break;
         case Pyc::LOAD_CONST_A:
@@ -1161,6 +1164,10 @@ PycRef<ASTNode> BuildFromCode(PycRef<PycCode> code, PycModule* mod)
                     if (curblock->blktype() == ASTBlock::BLK_FOR
                             && !curblock->inited()) {
                         curblock.cast<ASTIterBlock>()->setIndex(name);
+                    } else if (stack.top()->type() == ASTNode::NODE_IMPORT) {
+                        PycRef<ASTImport> import = stack.top().cast<ASTImport>();
+
+                        import->add_store(new ASTStore(value, name));
                     } else {
                         curblock->append(new ASTStore(value, name));
 
@@ -1663,6 +1670,47 @@ void print_src(PycRef<ASTNode> node, PycModule* mod)
             printf(":");
             if (slice->op() & ASTSlice::SLICE2) {
                 print_src(slice->right(), mod);
+            }
+        }
+        break;
+    case ASTNode::NODE_IMPORT:
+        {
+            PycRef<ASTImport> import = node.cast<ASTImport>();
+            if (import->stores().size()) {
+                ASTImport::list_t stores = import->stores();
+
+                printf("from ");
+                if (import->name()->type() == ASTNode::NODE_IMPORT)
+                    print_src(import->name().cast<ASTImport>()->name(), mod);
+                else
+                    print_src(import->name(), mod);
+                printf(" import ");
+
+                ASTImport::list_t::const_iterator ii = stores.begin();
+                if (stores.size() == 1) {
+                    print_src((*ii)->src(), mod);
+
+                    if ((*ii)->src().cast<ASTName>()->name()->value() != (*ii)->dest().cast<ASTName>()->name()->value()) {
+                        printf(" as ");
+                        print_src((*ii)->dest(), mod);
+                    }
+                } else {
+                    bool first = true;
+                    for (; ii != stores.end(); ++ii) {
+                        if (!first)
+                            printf(", ");
+                        print_src((*ii)->src(), mod);
+                        first = false;
+
+                        if ((*ii)->src().cast<ASTName>()->name()->value() != (*ii)->dest().cast<ASTName>()->name()->value()) {
+                            printf(" as ");
+                            print_src((*ii)->dest(), mod);
+                        }
+                    }
+                }
+            } else {
+                printf("import ");
+                print_src(import->name(), mod);
             }
         }
         break;


### PR DESCRIPTION
This adds the DUP_TOPX and DUP_TOP_TWO ops to duplicate stack entities.

It also adds support for the extended import syntax:

``` python
from blah import foo as bar
```
