### PR TITLE
More fixes

### DIFF
--- a/ASTree.cpp
+++ b/ASTree.cpp
@@ -1254,6 +1254,13 @@ PycRef<ASTNode> BuildFromCode(PycRef<PycCode> code, PycModule* mod)
                         curblock = blocks.top();
                     }
                 }
+
+                if (curblock->blktype() == ASTBlock::BLK_FOR
+                        && curblock->end() == pos) {
+                    blocks.pop();
+                    blocks.top()->append(curblock.cast<ASTNode>());
+                    curblock = blocks.top();
+                }
             }
             break;
         case Pyc::POP_EXCEPT:


### PR DESCRIPTION
Fixes for more block combinations, and also that tuple assignment issue I had mentioned.

The Python 2.2 stdlib should decompyle with no pycdc errors.
