### PR TITLE
Fix almost all my test cases

### DIFF
--- a/ASTree.cpp
+++ b/ASTree.cpp
@@ -951,6 +951,20 @@ PycRef<ASTNode> BuildFromCode(PycRef<PycCode> code, PycModule* mod)
 
                         blocks.pop();
                         curblock = blocks.top();
+                    } if (curblock->blktype() == ASTBlock::BLK_ELSE) {
+                        stack = stack_hist.top();
+                        stack_hist.pop();
+
+                        blocks.pop();
+                        blocks.top()->append(curblock.cast<ASTNode>());
+                        curblock = blocks.top();
+
+                        if (curblock->blktype() == ASTBlock::BLK_CONTAINER
+                                && !curblock.cast<ASTContainerBlock>()->hasFinally()) {
+                            blocks.pop();
+                            blocks.top()->append(curblock.cast<ASTNode>());
+                            curblock = blocks.top();
+                        }
                     } else {
                         curblock->append(new ASTKeyword(ASTKeyword::KW_CONTINUE));
                     }


### PR DESCRIPTION
2 known issues.

Lambdas with complex boolean statements aren't output correctly.

``` python
filter(lambda x: x.lower() in _browsers or x.find("%s") > -1, _tryorder)

# Comes out as:
filter(lambda x: if not x.lower() in _browsers: x.find("%s") > -1, _tryorder)
```

Sometimes missing the else statement of try/except/else blocks.

``` python
for x in blah:
    try:
        something
    except Error:
        try:
            something_else
        except Error:
            pass
    else:
        print 'error' #This escapes to the scope of the for block
```
