### PR TITLE
Correct loading of PycCFloat and PycCComplex

### DIFF
--- a/pyc_numeric.cpp
+++ b/pyc_numeric.cpp
@@ -153,7 +153,8 @@ bool PycComplex::isEqual(PycRef<PycObject> obj) const
 /* PycCFloat */
 void PycCFloat::load(PycData* stream, PycModule*)
 {
-    m_value = (double)stream->get64();
+    Pyc_INT64 tmp = stream->get64();
+    memcpy(&m_value,&tmp,8);
 }
 
 
@@ -161,5 +162,6 @@ void PycCFloat::load(PycData* stream, PycModule*)
 void PycCComplex::load(PycData* stream, PycModule* mod)
 {
     PycCFloat::load(stream, mod);
-    m_imag = (double)stream->get64();
+    Pyc_INT64 tmp = stream->get64();
+    memcpy(&m_imag,&tmp,8);
 }


### PR DESCRIPTION
Original version made conversion int64->double 'by value', instead of 'by representation', resulting in garbage floats in output (smf. like 4.67062e+18), otherwise clean and sound.
