### PR TITLE
add "await" (for 3.5 when @asyncio.coroutine Decorator is not used), …

### DIFF
--- a/ASTNode.cpp
+++ b/ASTNode.cpp
@@ -55,7 +55,7 @@ const char* ASTCompare::op_str() const
 const char* ASTKeyword::word_str() const
 {
     static const char* s_word_strings[] = {
-        "break", "continue"
+        "break", "continue", /*Seems that await and yield from can go here. Although I hope I am not wrong on this.*/ "await", "yield from"
     };
     return s_word_strings[key()];
 }


### PR DESCRIPTION
…and yield from for when it is.

At least now lets hope this thing gets support for decorators on top of functions (for coroutines mainly) without wrapping them first.
