### PR TITLE
Add MAGIC_NUMBER for Python 3.5.2

### DIFF
--- a/PythonBytecode.txt
+++ b/PythonBytecode.txt
@@ -5,8 +5,8 @@ Python  MAGIC           Python  MAGIC           Python  MAGIC
 1.3     0x0A0D2E89      2.3     0x0A0DF23B      3.3     0x0A0D0C9E
 1.4     0x0A0D1704      2.4     0x0A0DF26D      3.4     0x0A0D0CEE
 1.5     0x0A0D4E99      2.5     0x0A0DF2B3      3.5     0x0A0D0D16
-1.6     0x0A0DC4FC      2.6     0x0A0DF2D1      3.6     0x0A0D0D33
-                        2.7     0x0A0DF303
+1.6     0x0A0DC4FC      2.6     0x0A0DF2D1      3.5.3   0x0A0D0D17
+                        2.7     0x0A0DF303      3.6     0x0A0D0D33
 
 
                         1.0     1.1     1.2     1.3     1.4     1.5     1.6

--- a/pyc_module.cpp
+++ b/pyc_module.cpp
@@ -125,6 +125,9 @@ void PycModule::setVersion(unsigned int magic)
         break;
 
     case MAGIC_3_5:
+	/* fall through */
+
+    case MAGIC_3_5_3:
         m_maj = 3;
         m_min = 5;
         m_unicode = true;

--- a/pyc_module.h
+++ b/pyc_module.h
@@ -27,6 +27,7 @@ enum PycMagic {
     MAGIC_3_3 = 0x0A0D0C9E,
     MAGIC_3_4 = 0x0A0D0CEE,
     MAGIC_3_5 = 0x0A0D0D16,
+    MAGIC_3_5_3 = 0x0A0D0D17,
     MAGIC_3_6 = 0x0A0D0D33,
 };
 


### PR DESCRIPTION
See https://bugs.python.org/issue27286 for some details. Python 3.5.2 uses "3351" as the magic number.

This change can also be verified [at this url](https://github.com/python/cpython/blob/master/Lib/importlib/_bootstrap_external.py).

I chose the string `MAGIC_352` over `MAGIC_3_5_2` to preserve the existing code indentation.