### PR TITLE
Fixed crash on stack_history being empty

### DIFF
--- a/ASTree.cpp
+++ b/ASTree.cpp
@@ -1395,8 +1395,12 @@ PycRef<ASTNode> BuildFromCode(PycRef<PycCode> code, PycModule* mod)
                         || curblock->blktype() == ASTBlock::BLK_TRY
                         || curblock->blktype() == ASTBlock::BLK_EXCEPT
                         || curblock->blktype() == ASTBlock::BLK_FINALLY) {
-                    stack = stack_hist.top();
-                    stack_hist.pop();
+                    if (!stack_hist.empty()) {
+                        stack = stack_hist.top();
+                        stack_hist.pop();
+                    } else {
+                        fprintf(stderr, "Warning: Stack history is empty, something wrong might have happened\n");
+                    }
                 }
 
                 tmp = curblock;


### PR DESCRIPTION
Signed-off-by: Alexis Maiquez Murcia <almamu@almamu.com>

Should fix issue #35 
I've added a warning message because I'm not exactly sure that this situation is expected and/or desirable.