### PR TITLE
Changes in 3.10 under BPO-27129: "Use instruction offset, rather than bytecode offset"

### DIFF
--- a/bytecode.h
+++ b/bytecode.h
@@ -25,6 +25,7 @@ bool IsNameArg(int opcode);
 bool IsVarNameArg(int opcode);
 bool IsCellArg(int opcode);
 bool IsJumpOffsetArg(int opcode);
+bool IsJumpArg(int opcode);
 bool IsCompareArg(int opcode);
 
 }


### PR DESCRIPTION
3.10 changed all jumps offsets.

See [BPO-27129](https://bugs.python.org/issue27129) and [changes in compile.c](https://github.com/python/cpython/commit/fcb55c0037baab6f98f91ee38ce84b6f874f034a)

This will fix pycdc, not clear what pycdas should show (as operand value).
