### PR TITLE
Add debug output of asm instructions in pycdc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Debug options.
 option(ENABLE_BLOCK_DEBUG "Enable block debugging" OFF)
 option(ENABLE_STACK_DEBUG "Enable stack debugging" OFF)
+option(ENABLE_ASM_DEBUG "Enable assembly debugging" OFF)
 
 # Turn debug defs on if they're enabled.
 if (ENABLE_BLOCK_DEBUG)
@@ -14,6 +15,9 @@ if (ENABLE_BLOCK_DEBUG)
 endif()
 if (ENABLE_STACK_DEBUG)
     add_definitions(-DSTACK_DEBUG)
+endif()
+if (ENABLE_ASM_DEBUG)
+    add_definitions(-DASM_DEBUG)
 endif()
 
 # For generating the bytes tables

--- a/bytecode.cpp
+++ b/bytecode.cpp
@@ -2,6 +2,9 @@
 #include "bytecode.h"
 #include <stdexcept>
 #include <cmath>
+#include <memory>
+#include <string>
+#include <stdexcept>
 
 #ifdef _MSC_VER
 #define snprintf _snprintf
@@ -156,21 +159,22 @@ bool Pyc::IsCompareArg(int opcode)
     return (opcode == Pyc::COMPARE_OP_A);
 }
 
-void print_const(PycRef<PycObject> obj, PycModule* mod, const char* parent_f_string_quote)
+std::string const_to_string(PycRef<PycObject> obj, PycModule* mod, const char* parent_f_string_quote)
 {
+    std::string result;
+
     if (obj == NULL) {
-        fputs("<NULL>", pyc_output);
-        return;
+        return "<NULL>";
     }
 
     switch (obj->type()) {
     case PycObject::TYPE_STRING:
-        OutputString(obj.cast<PycString>(), mod->strIsUnicode() ? 'b' : 0,
-                     false, pyc_output, parent_f_string_quote);
+        result += OutputString(obj.cast<PycString>(), mod->strIsUnicode() ? 'b' : 0,
+                     false, parent_f_string_quote);
         break;
     case PycObject::TYPE_UNICODE:
-        OutputString(obj.cast<PycString>(), mod->strIsUnicode() ? 0 : 'u',
-                     false, pyc_output, parent_f_string_quote);
+        result += OutputString(obj.cast<PycString>(), mod->strIsUnicode() ? 0 : 'u',
+                     false, parent_f_string_quote);
         break;
     case PycObject::TYPE_STRINGREF:
     case PycObject::TYPE_INTERNED:
@@ -179,105 +183,105 @@ void print_const(PycRef<PycObject> obj, PycModule* mod, const char* parent_f_str
     case PycObject::TYPE_SHORT_ASCII:
     case PycObject::TYPE_SHORT_ASCII_INTERNED:
         if (mod->majorVer() >= 3)
-            OutputString(obj.cast<PycString>(), 0, false, pyc_output, parent_f_string_quote);
+            result += OutputString(obj.cast<PycString>(), 0, false, parent_f_string_quote);
         else
-            OutputString(obj.cast<PycString>(), mod->strIsUnicode() ? 'b' : 0,
-                         false, pyc_output, parent_f_string_quote);
+            result += OutputString(obj.cast<PycString>(), mod->strIsUnicode() ? 'b' : 0,
+                         false, parent_f_string_quote);
         break;
     case PycObject::TYPE_TUPLE:
     case PycObject::TYPE_SMALL_TUPLE:
         {
-            fputs("(", pyc_output);
+            result = "(";
             PycTuple::value_t values = obj.cast<PycTuple>()->values();
             auto it = values.cbegin();
             if (it != values.cend()) {
-                print_const(*it, mod);
+                result += const_to_string(*it, mod);
                 while (++it != values.cend()) {
-                    fputs(", ", pyc_output);
-                    print_const(*it, mod);
+                    result += ", ";
+                    result += const_to_string(*it, mod);
                 }
             }
             if (values.size() == 1)
-                fputs(",)", pyc_output);
+                result += ",)";
             else
-                fputs(")", pyc_output);
+                result +=  ")";
         }
         break;
     case PycObject::TYPE_LIST:
         {
-            fputs("[", pyc_output);
+            result += "[";
             PycList::value_t values = obj.cast<PycList>()->values();
             auto it = values.cbegin();
             if (it != values.cend()) {
-                print_const(*it, mod);
+                result += const_to_string(*it, mod);
                 while (++it != values.cend()) {
-                    fputs(", ", pyc_output);
-                    print_const(*it, mod);
+                    result += ", ";
+                    result += const_to_string(*it, mod);
                 }
             }
-            fputs("]", pyc_output);
+            result += "]";
         }
         break;
     case PycObject::TYPE_DICT:
         {
-            fputs("{", pyc_output);
+            result += "{";
             PycDict::key_t keys = obj.cast<PycDict>()->keys();
             PycDict::value_t values = obj.cast<PycDict>()->values();
             auto ki = keys.cbegin();
             auto vi = values.cbegin();
             if (ki != keys.cend()) {
-                print_const(*ki, mod);
-                fputs(": ", pyc_output);
-                print_const(*vi, mod);
+                result += const_to_string(*ki, mod);
+                result += ": ";
+                result += const_to_string(*vi, mod);
                 while (++ki != keys.cend()) {
                     ++vi;
-                    fputs(", ", pyc_output);
-                    print_const(*ki, mod);
-                    fputs(": ", pyc_output);
-                    print_const(*vi, mod);
+                    result += ", ";
+                    result += const_to_string(*ki, mod);
+                    result += ": ";
+                    result += const_to_string(*vi, mod);
                 }
             }
-            fputs("}", pyc_output);
+            result += "}";
         }
         break;
     case PycObject::TYPE_SET:
         {
-            fputs("{", pyc_output);
+            result += "{";
             PycSet::value_t values = obj.cast<PycSet>()->values();
             auto it = values.cbegin();
             if (it != values.cend()) {
-                print_const(*it, mod);
+                result += const_to_string(*it, mod);
                 while (++it != values.cend()) {
-                    fputs(", ", pyc_output);
-                    print_const(*it, mod);
+                    result += ", ";
+                    result += const_to_string(*it, mod);
                 }
             }
-            fputs("}", pyc_output);
+            result += "}";
         }
         break;
     case PycObject::TYPE_NONE:
-        fputs("None", pyc_output);
+        result += "None";
         break;
     case PycObject::TYPE_TRUE:
-        fputs("True", pyc_output);
+        result += "True";
         break;
     case PycObject::TYPE_FALSE:
-        fputs("False", pyc_output);
+        result += "False";
         break;
     case PycObject::TYPE_ELLIPSIS:
-        fputs("...", pyc_output);
+        result += "...";
         break;
     case PycObject::TYPE_INT:
-        fprintf(pyc_output, "%d", obj.cast<PycInt>()->value());
+        result += string_format("%d", obj.cast<PycInt>()->value());
         break;
     case PycObject::TYPE_LONG:
-        fprintf(pyc_output, "%s", obj.cast<PycLong>()->repr().c_str());
+        result += string_format("%s", obj.cast<PycLong>()->repr().c_str());
         break;
     case PycObject::TYPE_FLOAT:
-        fprintf(pyc_output, "%s", obj.cast<PycFloat>()->value());
+        result += string_format("%s", obj.cast<PycFloat>()->value());
         break;
     case PycObject::TYPE_COMPLEX:
-        fprintf(pyc_output, "(%s+%sj)", obj.cast<PycComplex>()->value(),
+        result += string_format("(%s+%sj)", obj.cast<PycComplex>()->value(),
                                         obj.cast<PycComplex>()->imag());
         break;
     case PycObject::TYPE_BINARY_FLOAT:
@@ -287,30 +291,31 @@ void print_const(PycRef<PycObject> obj, PycModule* mod, const char* parent_f_str
             bool is_negative = std::signbit(value);
             if (std::isnan(value)) {
                 if (is_negative) {
-                    fprintf(pyc_output, "float('-nan')");
+                    result += string_format("float('-nan')");
                 } else {
-                    fprintf(pyc_output, "float('nan')");
+                    result += string_format("float('nan')");
                 }
             } else if (std::isinf(value)) {
                 if (is_negative) {
-                    fprintf(pyc_output, "float('-inf')");
+                    result += string_format("float('-inf')");
                 } else {
-                    fprintf(pyc_output, "float('inf')");
+                    result += string_format("float('inf')");
                 }
             } else {
-                fprintf(pyc_output, "%g", value);
+                result += string_format("%g", value);
             }
         }
         break;
     case PycObject::TYPE_BINARY_COMPLEX:
-        fprintf(pyc_output, "(%g+%gj)", obj.cast<PycCComplex>()->value(),
+        result += string_format("(%g+%gj)", obj.cast<PycCComplex>()->value(),
                                         obj.cast<PycCComplex>()->imag());
         break;
     case PycObject::TYPE_CODE:
     case PycObject::TYPE_CODE2:
-        fprintf(pyc_output, "<CODE> %s", obj.cast<PycCode>()->name()->value());
+        result += string_format("<CODE> %s", obj.cast<PycCode>()->name()->value());
         break;
     }
+    return result;
 }
 
 void bc_next(PycBuffer& source, PycModule* mod, int& opcode, int& operand, int& pos)
@@ -343,14 +348,75 @@ void bc_next(PycBuffer& source, PycModule* mod, int& opcode, int& operand, int& 
     }
 }
 
-void bc_disasm(PycRef<PycCode> code, PycModule* mod, int indent)
-{
+std::string bc_instruction_to_string(PycRef<PycCode> code, PycModule* mod, int pos, int opcode, int operand) {
     static const char *cmp_strings[] = {
         "<", "<=", "==", "!=", ">", ">=", "in", "not in", "is", "is not",
         "<EXCEPTION MATCH>", "<BAD>"
     };
     static const size_t cmp_strings_len = sizeof(cmp_strings) / sizeof(cmp_strings[0]);
 
+    std::string result = string_format("%-24s", Pyc::OpcodeName(opcode));
+
+    if (opcode >= Pyc::PYC_HAVE_ARG) {
+        if (Pyc::IsConstArg(opcode)) {
+            try {
+                auto constParam = code->getConst(operand);
+                result += string_format("%d: ", operand);
+                result += const_to_string(constParam, mod);
+            } catch (const std::out_of_range &) {
+                result += string_format("%d <INVALID>", operand);
+            }
+        } else if (Pyc::IsNameArg(opcode)) {
+            try {
+                result += string_format("%d: %s", operand, code->getName(operand)->value());
+            } catch (const std::out_of_range &) {
+                result += string_format("%d <INVALID>", operand);
+            }
+        } else if (Pyc::IsVarNameArg(opcode)) {
+            try {
+                result += string_format("%d: %s", operand, code->getVarName(operand)->value());
+            } catch (const std::out_of_range &) {
+                result += string_format("%d <INVALID>", operand);
+            }
+        } else if (Pyc::IsCellArg(opcode)) {
+            try {
+                result += string_format("%d: %s", operand, code->getCellVar(operand)->value());
+            } catch (const std::out_of_range &) {
+                result += string_format("%d <INVALID>", operand);
+            }
+        } else if (Pyc::IsJumpOffsetArg(opcode)) {
+            int offs = operand;
+            if (mod->verCompare(3, 10) >= 0)
+                offs *= sizeof(uint16_t); // BPO-27129
+            result += string_format("%d (to %d)", operand, pos+offs);
+        }
+        else if (Pyc::IsJumpArg(opcode)) {
+            if (mod->verCompare(3, 10) >= 0) // BPO-27129
+                result += string_format("%d (to %d)", operand, int(operand * sizeof(uint16_t)));
+            else
+                result += string_format("%d", operand);
+        } else if (Pyc::IsCompareArg(opcode)) {
+            if (static_cast<size_t>(operand) < cmp_strings_len)
+                result += string_format("%d (%s)", operand, cmp_strings[operand]);
+            else
+                result += string_format("%d (UNKNOWN)", operand);
+        } else if (opcode == Pyc::IS_OP_A) {
+            result += string_format("%d (%s)", operand, (operand == 0) ? "is"
+                                                  : (operand == 1) ? "is not"
+                                                  : "UNKNOWN");
+        } else if (opcode == Pyc::CONTAINS_OP_A) {
+            result += string_format("%d (%s)", operand, (operand == 0) ? "in"
+                                                  : (operand == 1) ? "not in"
+                                                  : "UNKNOWN");
+        } else {
+            result += string_format("%d", operand);
+        }
+    }
+    return result;
+}
+
+void bc_disasm(PycRef<PycCode> code, PycModule* mod, int indent)
+{
     PycBuffer source(code->code()->value(), code->code()->length());
 
     int opcode, operand;
@@ -359,65 +425,10 @@ void bc_disasm(PycRef<PycCode> code, PycModule* mod, int indent)
         for (int i=0; i<indent; i++)
             fputs("    ", pyc_output);
         fprintf(pyc_output, "%-7d ", pos);   // Current bytecode position
+        std::string instruction = bc_instruction_to_string(code, mod, pos, opcode, operand);
+        fputs(instruction.c_str(), pyc_output);
 
         bc_next(source, mod, opcode, operand, pos);
-        fprintf(pyc_output, "%-24s", Pyc::OpcodeName(opcode));
-
-        if (opcode >= Pyc::PYC_HAVE_ARG) {
-            if (Pyc::IsConstArg(opcode)) {
-                try {
-                    auto constParam = code->getConst(operand);
-                    fprintf(pyc_output, "%d: ", operand);
-                    print_const(constParam, mod);
-                } catch (const std::out_of_range &) {
-                    fprintf(pyc_output, "%d <INVALID>", operand);
-                }
-            } else if (Pyc::IsNameArg(opcode)) {
-                try {
-                    fprintf(pyc_output, "%d: %s", operand, code->getName(operand)->value());
-                } catch (const std::out_of_range &) {
-                    fprintf(pyc_output, "%d <INVALID>", operand);
-                }
-            } else if (Pyc::IsVarNameArg(opcode)) {
-                try {
-                    fprintf(pyc_output, "%d: %s", operand, code->getVarName(operand)->value());
-                } catch (const std::out_of_range &) {
-                    fprintf(pyc_output, "%d <INVALID>", operand);
-                }
-            } else if (Pyc::IsCellArg(opcode)) {
-                try {
-                    fprintf(pyc_output, "%d: %s", operand, code->getCellVar(operand)->value());
-                } catch (const std::out_of_range &) {
-                    fprintf(pyc_output, "%d <INVALID>", operand);
-                }
-            } else if (Pyc::IsJumpOffsetArg(opcode)) {
-                int offs = operand;
-                if (mod->verCompare(3, 10) >= 0)
-                    offs *= sizeof(uint16_t); // BPO-27129
-                fprintf(pyc_output, "%d (to %d)", operand, pos+offs);
-            }
-            else if (Pyc::IsJumpArg(opcode)) {
-                if (mod->verCompare(3, 10) >= 0) // BPO-27129
-                    fprintf(pyc_output, "%d (to %d)", operand, int(operand * sizeof(uint16_t)));
-                else
-                    fprintf(pyc_output, "%d", operand);
-            } else if (Pyc::IsCompareArg(opcode)) {
-                if (static_cast<size_t>(operand) < cmp_strings_len)
-                    fprintf(pyc_output, "%d (%s)", operand, cmp_strings[operand]);
-                else
-                    fprintf(pyc_output, "%d (UNKNOWN)", operand);
-            } else if (opcode == Pyc::IS_OP_A) {
-                fprintf(pyc_output, "%d (%s)", operand, (operand == 0) ? "is"
-                                                      : (operand == 1) ? "is not"
-                                                      : "UNKNOWN");
-            } else if (opcode == Pyc::CONTAINS_OP_A) {
-                fprintf(pyc_output, "%d (%s)", operand, (operand == 0) ? "in"
-                                                      : (operand == 1) ? "not in"
-                                                      : "UNKNOWN");
-            } else {
-                fprintf(pyc_output, "%d", operand);
-            }
-        }
         fputs("\n", pyc_output);
     }
 }

--- a/bytecode.h
+++ b/bytecode.h
@@ -30,6 +30,7 @@ bool IsCompareArg(int opcode);
 
 }
 
-void print_const(PycRef<PycObject> obj, PycModule* mod, const char* parent_f_string_quote = nullptr);
+std::string const_to_string(PycRef<PycObject> obj, PycModule* mod, const char* parent_f_string_quote = nullptr);
 void bc_next(PycBuffer& source, PycModule* mod, int& opcode, int& operand, int& pos);
+std::string bc_instruction_to_string(PycRef<PycCode> code, PycModule* mod, int pos, int opcode, int operand);
 void bc_disasm(PycRef<PycCode> code, PycModule* mod, int indent);

--- a/pyc_string.h
+++ b/pyc_string.h
@@ -5,6 +5,8 @@
 #include "data.h"
 #include <cstdio>
 #include <string>
+#include <stdexcept>
+#include <memory>
 
 class PycString : public PycObject {
 public:
@@ -31,7 +33,18 @@ private:
     std::string m_value;
 };
 
-void OutputString(PycRef<PycString> str, char prefix = 0, bool triple = false,
-                  FILE* F = pyc_output, const char* parent_f_string_quote = nullptr);
+std::string OutputString(PycRef<PycString> str, char prefix = 0, bool triple = false,
+                  const char* parent_f_string_quote = nullptr);
+
+template<typename ... Args>
+std::string string_format( const std::string& format, Args ... args )
+{
+    int size_s = std::snprintf( nullptr, 0, format.c_str(), args ... ) + 1; // Extra space for '\0'
+    if( size_s <= 0 ){ throw std::runtime_error( "Error during formatting." ); }
+    auto size = static_cast<size_t>( size_s );
+    std::unique_ptr<char[]> buf( new char[ size ] );
+    std::snprintf( buf.get(), size, format.c_str(), args ... );
+    return std::string( buf.get(), buf.get() + size - 1 ); // We don't want the '\0' inside
+}
 
 #endif

--- a/pycdas.cpp
+++ b/pycdas.cpp
@@ -131,14 +131,18 @@ void output_object(PycRef<PycObject> obj, PycModule* mod, int indent)
         }
         break;
     case PycObject::TYPE_STRING:
-        iputs(indent, "");
-        OutputString(obj.cast<PycString>(), mod->strIsUnicode() ? 'b' : 0);
-        fputs("\n", pyc_output);
+        {
+            iputs(indent, "");
+            std::string s = OutputString(obj.cast<PycString>(), mod->strIsUnicode() ? 'b' : 0) + "\n";
+            fputs(s.c_str(), pyc_output);
+        }
         break;
     case PycObject::TYPE_UNICODE:
-        iputs(indent, "");
-        OutputString(obj.cast<PycString>(), mod->strIsUnicode() ? 0 : 'u');
-        fputs("\n", pyc_output);
+        {
+            iputs(indent, "");
+            std::string s = OutputString(obj.cast<PycString>(), mod->strIsUnicode() ? 0 : 'u') + "\n";
+            fputs(s.c_str(), pyc_output);
+        }
         break;
     case PycObject::TYPE_STRINGREF:
     case PycObject::TYPE_INTERNED:
@@ -146,12 +150,16 @@ void output_object(PycRef<PycObject> obj, PycModule* mod, int indent)
     case PycObject::TYPE_ASCII_INTERNED:
     case PycObject::TYPE_SHORT_ASCII:
     case PycObject::TYPE_SHORT_ASCII_INTERNED:
-        iputs(indent, "");
-        if (mod->majorVer() >= 3)
-            OutputString(obj.cast<PycString>(), 0);
-        else
-            OutputString(obj.cast<PycString>(), mod->strIsUnicode() ? 'b' : 0);
-        fputs("\n", pyc_output);
+        {
+            iputs(indent, "");
+            std::string s;
+            if (mod->majorVer() >= 3)
+                s = OutputString(obj.cast<PycString>(), 0);
+            else
+                s = OutputString(obj.cast<PycString>(), mod->strIsUnicode() ? 'b' : 0);
+            fputs(s.c_str(), pyc_output);
+            fputs("\n", pyc_output);
+        }
         break;
     case PycObject::TYPE_TUPLE:
     case PycObject::TYPE_SMALL_TUPLE:


### PR DESCRIPTION
I found it useful to see assembly and block scopes next to each other.
The PR changes some disassembly functions to output strings instead of directly writing to the stdout.

Output (set `ENABLE_ASM_DEBUG` in cmake to see it)
```
3      SET_LINENO              0               1         (0)
6      LOAD_CONST              0: '\ntest_lo...1         (0)
9      STORE_NAME              0: __doc__      1         (0)
12     SET_LINENO              9               1         (0)
15     SET_LINENO              14              1         (0)
18     SETUP_LOOP              54 (to 72)      1         (0)
21     LOAD_NAME               1: args         1            while (72)
22     GET_ITER                                1            while (72)
25     SET_LINENO              14              1            while (72)
28     FOR_ITER                43 (to 71)      1            while (72)
31     STORE_NAME              2: term         1            for (72)
34     SET_LINENO              15              1            for (72)
37     SETUP_EXCEPT            18 (to 55)      1            for (72)
40     SET_LINENO              16              2                    try (55)
41     PRINT_NEWLINE                           2                    try (55)
44     SET_LINENO              17              2                    try (55)
47     CONTINUE_LOOP           22              2                    try (55)
50     SET_LINENO              18              2                    try (55)
51     PRINT_NEWLINE                           2                    try (55)
52     POP_BLOCK                               2                    try (55)
55     JUMP_FORWARD            13 (to 68)      1                CONTAINER (0)
58     SET_LINENO              19              2                    except (68)
59     POP_TOP                                 2                    except (68)
60     POP_TOP                                 2                    except (68)
61     POP_TOP                                 2                    except (68)
64     SET_LINENO              20              2                    except (68)
67     JUMP_FORWARD            1 (to 68)       2                    except (68)
68     END_FINALLY                             2                    except (68)
71     JUMP_ABSOLUTE           22              1            for (72)
72     POP_BLOCK                               1            for (72)
75     LOAD_CONST              1: None         2            else (72)
76     RETURN_VALUE                            1         (0)
```