### PR TITLE
Added recursion depth limiting

### DIFF
--- a/ASTree.h
+++ b/ASTree.h
@@ -4,8 +4,8 @@
 #include "ASTNode.h"
 
 PycRef<ASTNode> BuildFromCode(PycRef<PycCode> code, PycModule* mod);
-void print_src(PycRef<ASTNode> node, PycModule* mod);
+void print_src(PycRef<ASTNode> node, PycModule* mod, int currentDepth, int maxDepth);
 
-void decompyle(PycRef<PycCode> code, PycModule* mod);
+void decompyle(PycRef<PycCode> code, PycModule* mod, int currentDepth, int maxDepth);
 
 #endif

--- a/pyc_code.cpp
+++ b/pyc_code.cpp
@@ -2,73 +2,140 @@
 #include "pyc_module.h"
 #include "data.h"
 
-void PycCode::load(PycData* stream, PycModule* mod)
+void PycCode::load(PycData* stream, PycModule* mod, int currentDepth, int maxDepth)
 {
     if (mod->verCompare(1, 3) >= 0 && mod->verCompare(2, 3) < 0)
+	{
         m_argCount = stream->get16();
+	}
     else if (mod->verCompare(2, 3) >= 0)
+	{
         m_argCount = stream->get32();
+	}
 
     if (mod->verCompare(3, 8) >= 0)
+	{
         m_posOnlyArgCount = stream->get32();
+	}
     else
+	{
         m_posOnlyArgCount = 0;
+	}
 
     if (mod->majorVer() >= 3)
+	{
         m_kwOnlyArgCount = stream->get32();
+	}
     else
+	{
         m_kwOnlyArgCount = 0;
+	}
 
     if (mod->verCompare(1, 3) >= 0 && mod->verCompare(2, 3) < 0)
+	{
         m_numLocals = stream->get16();
+	}
     else if (mod->verCompare(2, 3) >= 0)
+	{
         m_numLocals = stream->get32();
+	}
     else
+	{
         m_numLocals = 0;
+	}
 
     if (mod->verCompare(1, 5) >= 0 && mod->verCompare(2, 3) < 0)
+	{
         m_stackSize = stream->get16();
+	}
     else if (mod->verCompare(2, 3) >= 0)
+	{
         m_stackSize = stream->get32();
+	}
     else
+	{
         m_stackSize = 0;
+	}
 
     if (mod->verCompare(1, 3) >= 0 && mod->verCompare(2, 3) < 0)
+	{
         m_flags = stream->get16();
+	}
     else if (mod->verCompare(2, 3) >= 0)
+	{
         m_flags = stream->get32();
+	}
     else
+	{
         m_flags = 0;
+	}
+    
+	if (CheckRecursionDepth(currentDepth, maxDepth))
+	{
+		m_code = LoadObject(stream, mod, currentDepth + 1, maxDepth).require_cast<PycString>();
+		m_consts = LoadObject(stream, mod, currentDepth + 1, maxDepth).require_cast<PycSequence>();
+		m_names = LoadObject(stream, mod, currentDepth + 1, maxDepth).require_cast<PycSequence>();
+	}
+	else
+	{
+		m_code = new PycString;
+		m_consts = new PycTuple;
+		m_names = new PycTuple;
+	}
 
-    m_code = LoadObject(stream, mod).require_cast<PycString>();
-    m_consts = LoadObject(stream, mod).require_cast<PycSequence>();
-    m_names = LoadObject(stream, mod).require_cast<PycSequence>();
-
-    if (mod->verCompare(1, 3) >= 0)
-        m_varNames = LoadObject(stream, mod).require_cast<PycSequence>();
+    if ((mod->verCompare(1, 3) >= 0) && CheckRecursionDepth(currentDepth, maxDepth))
+	{
+        m_varNames = LoadObject(stream, mod, currentDepth + 1, maxDepth).require_cast<PycSequence>();
+	}
     else
+	{
         m_varNames = new PycTuple;
+	}
 
-    if (mod->verCompare(2, 1) >= 0)
-        m_freeVars = LoadObject(stream, mod).require_cast<PycSequence>();
+    if ((mod->verCompare(2, 1) >= 0) && CheckRecursionDepth(currentDepth, maxDepth))
+	{
+        m_freeVars = LoadObject(stream, mod, currentDepth + 1, maxDepth).require_cast<PycSequence>();
+	}
     else
+	{
         m_freeVars = new PycTuple;
+	}
 
-    if (mod->verCompare(2, 1) >= 0)
-        m_cellVars = LoadObject(stream, mod).require_cast<PycSequence>();
+    if ((mod->verCompare(2, 1) >= 0) && CheckRecursionDepth(currentDepth, maxDepth))
+	{
+        m_cellVars = LoadObject(stream, mod, currentDepth + 1, maxDepth).require_cast<PycSequence>();
+	}
     else
+	{
         m_cellVars = new PycTuple;
+	}
 
-    m_fileName = LoadObject(stream, mod).require_cast<PycString>();
-    m_name = LoadObject(stream, mod).require_cast<PycString>();
+	if (CheckRecursionDepth(currentDepth, maxDepth))
+	{
+		m_fileName = LoadObject(stream, mod, currentDepth + 1, maxDepth).require_cast<PycString>();
+		m_name = LoadObject(stream, mod, currentDepth + 1, maxDepth).require_cast<PycString>();
+	}
+	else
+	{
+		m_fileName = new PycString;
+		m_name = new PycString;
+	}
 
     if (mod->verCompare(1, 5) >= 0 && mod->verCompare(2, 3) < 0)
+	{
         m_firstLine = stream->get16();
+	}
     else if (mod->verCompare(2, 3) >= 0)
+	{
         m_firstLine = stream->get32();
+	}
 
-    if (mod->verCompare(1, 5) >= 0)
-        m_lnTable = LoadObject(stream, mod).require_cast<PycString>();
+    if ((mod->verCompare(1, 5) >= 0) && CheckRecursionDepth(currentDepth, maxDepth))
+	{
+        m_lnTable = LoadObject(stream, mod, currentDepth + 1, maxDepth).require_cast<PycString>();
+	}
     else
+	{
         m_lnTable = new PycString;
+	}
 }

--- a/pyc_code.h
+++ b/pyc_code.h
@@ -31,7 +31,7 @@ public:
         : PycObject(type), m_argCount(), m_posOnlyArgCount(), m_kwOnlyArgCount(),
           m_numLocals(), m_stackSize(), m_flags(), m_firstLine() { }
 
-    void load(class PycData* stream, class PycModule* mod) override;
+    void load(class PycData* stream, class PycModule* mod, int currentDepth, int maxDepth) override;
 
     int argCount() const { return m_argCount; }
     int posOnlyArgCount() const { return m_posOnlyArgCount; }

--- a/pyc_module.cpp
+++ b/pyc_module.cpp
@@ -166,12 +166,13 @@ void PycModule::setVersion(unsigned int magic)
 
     /* Bad Magic detected */
     default:
+	fprintf(stderr, "Unrecognized magic value: %x\n", magic);
         m_maj = -1;
         m_min = -1;
     }
 }
 
-void PycModule::loadFromFile(const char* filename)
+void PycModule::loadFromFile(const char* filename, int maxRecursionDepth)
 {
     PycFile in(filename);
     if (!in.isOpen()) {
@@ -199,10 +200,10 @@ void PycModule::loadFromFile(const char* filename)
             in.get32(); // Size parameter added in Python 3.3
     }
 
-    m_code = LoadObject(&in, this).require_cast<PycCode>();
+    m_code = LoadObject(&in, this, 0, maxRecursionDepth).require_cast<PycCode>();
 }
 
-void PycModule::loadFromMarshalledFile(const char* filename, int major, int minor)
+void PycModule::loadFromMarshalledFile(const char* filename, int major, int minor, int maxRecursionDepth)
 {
     PycFile in (filename);
     if (!in.isOpen()) {
@@ -215,7 +216,7 @@ void PycModule::loadFromMarshalledFile(const char* filename, int major, int mino
         return;
     }
     setVersion(magic);
-    m_code = LoadObject(&in, this).require_cast<PycCode>();
+    m_code = LoadObject(&in, this, 0, maxRecursionDepth).require_cast<PycCode>();
 }
 
 PycRef<PycString> PycModule::getIntern(int ref) const

--- a/pyc_module.h
+++ b/pyc_module.h
@@ -43,8 +43,8 @@ class PycModule {
 public:
     PycModule() : m_maj(-1), m_min(-1), m_unicode(false) { }
 
-    void loadFromFile(const char* filename);
-    void loadFromMarshalledFile(const char *filename, int major, int minor);
+    void loadFromFile(const char* filename, int maxRecursionDepth);
+    void loadFromMarshalledFile(const char *filename, int major, int minor, int maxRecursionDepth);
     bool isValid() const { return (m_maj >= 0) && (m_min >= 0); }
 
     int majorVer() const { return m_maj; }

--- a/pyc_numeric.cpp
+++ b/pyc_numeric.cpp
@@ -8,29 +8,35 @@
 #endif
 
 /* PycInt */
-void PycInt::load(PycData* stream, PycModule*)
+void PycInt::load(PycData* stream, PycModule*, int currentDepth, int maxDepth)
 {
-    m_value = stream->get32();
+	if (CheckRecursionDepth(currentDepth, maxDepth))
+	{
+		m_value = stream->get32();
+	}
 }
 
 
 /* PycLong */
-void PycLong::load(PycData* stream, PycModule*)
+void PycLong::load(PycData* stream, PycModule*, int currentDepth, int maxDepth)
 {
-    if (type() == TYPE_INT64) {
-        int lo = stream->get32();
-        int hi = stream->get32();
-        m_value.push_back((lo      ) & 0xFFFF);
-        m_value.push_back((lo >> 16) & 0xFFFF);
-        m_value.push_back((hi      ) & 0xFFFF);
-        m_value.push_back((hi >> 16) & 0xFFFF);
-        m_size = (hi & 0x80000000) != 0 ? -4 : 4;
-    } else {
-        m_size = stream->get32();
-        int actualSize = m_size >= 0 ? m_size : -m_size;
-        for (int i=0; i<actualSize; i++)
-            m_value.push_back(stream->get16());
-    }
+	if (CheckRecursionDepth(currentDepth, maxDepth))
+	{
+		if (type() == TYPE_INT64) {
+			int lo = stream->get32();
+			int hi = stream->get32();
+			m_value.push_back((lo      ) & 0xFFFF);
+			m_value.push_back((lo >> 16) & 0xFFFF);
+			m_value.push_back((hi      ) & 0xFFFF);
+			m_value.push_back((hi >> 16) & 0xFFFF);
+			m_size = (hi & 0x80000000) != 0 ? -4 : 4;
+		} else {
+			m_size = stream->get32();
+			int actualSize = m_size >= 0 ? m_size : -m_size;
+			for (int i=0; i<actualSize; i++)
+				m_value.push_back(stream->get16());
+		}
+	}
 }
 
 bool PycLong::isEqual(PycRef<PycObject> obj) const
@@ -94,15 +100,18 @@ std::string PycLong::repr() const
 
 
 /* PycFloat */
-void PycFloat::load(PycData* stream, PycModule*)
+void PycFloat::load(PycData* stream, PycModule*, int currentDepth, int maxDepth)
 {
-    int len = stream->getByte();
-    if (len < 0)
-        throw std::bad_alloc();
+	if (CheckRecursionDepth(currentDepth, maxDepth))
+	{
+		int len = stream->getByte();
+		if (len < 0)
+			throw std::bad_alloc();
 
-    m_value.resize(len);
-    if (len > 0)
-        stream->getBuffer(len, &m_value.front());
+		m_value.resize(len);
+		if (len > 0)
+			stream->getBuffer(len, &m_value.front());
+	}
 }
 
 bool PycFloat::isEqual(PycRef<PycObject> obj) const
@@ -116,17 +125,23 @@ bool PycFloat::isEqual(PycRef<PycObject> obj) const
 
 
 /* PycComplex */
-void PycComplex::load(PycData* stream, PycModule* mod)
+void PycComplex::load(PycData* stream, PycModule* mod, int currentDepth, int maxDepth)
 {
-    PycFloat::load(stream, mod);
+	if (CheckRecursionDepth(currentDepth, maxDepth))
+	{
+		PycFloat::load(stream, mod, currentDepth, maxDepth);
 
-    int len = stream->getByte();
-    if (len < 0)
-        throw std::bad_alloc();
-
-    m_imag.resize(len);
-    if (len > 0)
-        stream->getBuffer(len, &m_imag.front());
+		int len = stream->getByte();
+		if (len < 0)
+		{
+			throw std::bad_alloc();
+		}
+		m_imag.resize(len);
+		if (len > 0)
+		{
+			stream->getBuffer(len, &m_imag.front());
+		}
+	}
 }
 
 bool PycComplex::isEqual(PycRef<PycObject> obj) const
@@ -140,17 +155,23 @@ bool PycComplex::isEqual(PycRef<PycObject> obj) const
 
 
 /* PycCFloat */
-void PycCFloat::load(PycData* stream, PycModule*)
+void PycCFloat::load(PycData* stream, PycModule*, int currentDepth, int maxDepth)
 {
-    Pyc_INT64 bits = stream->get64();
-    memcpy(&m_value, &bits, sizeof(bits));
+	if (CheckRecursionDepth(currentDepth, maxDepth))
+	{
+		Pyc_INT64 bits = stream->get64();
+		memcpy(&m_value, &bits, sizeof(bits));
+	}
 }
 
 
 /* PycCComplex */
-void PycCComplex::load(PycData* stream, PycModule* mod)
+void PycCComplex::load(PycData* stream, PycModule* mod, int currentDepth, int maxDepth)
 {
-    PycCFloat::load(stream, mod);
-    Pyc_INT64 bits = stream->get64();
-    memcpy(&m_imag, &bits, sizeof(bits));
+	if (CheckRecursionDepth(currentDepth, maxDepth))
+	{
+		PycCFloat::load(stream, mod, currentDepth, maxDepth);
+		Pyc_INT64 bits = stream->get64();
+		memcpy(&m_imag, &bits, sizeof(bits));
+	}
 }

--- a/pyc_numeric.h
+++ b/pyc_numeric.h
@@ -17,7 +17,7 @@ public:
                (m_value == obj.cast<PycInt>()->m_value);
     }
 
-    void load(class PycData* stream, class PycModule* mod) override;
+    void load(class PycData* stream, class PycModule* mod, int currentDepth, int maxDepth) override;
 
     int value() const { return m_value; }
 
@@ -32,7 +32,7 @@ public:
 
     bool isEqual(PycRef<PycObject> obj) const override;
 
-    void load(class PycData* stream, class PycModule* mod) override;
+    void load(class PycData* stream, class PycModule* mod, int currentDepth, int maxDepth) override;
 
     int size() const { return m_size; }
     const std::list<int>& value() const { return m_value; }
@@ -51,7 +51,7 @@ public:
 
     bool isEqual(PycRef<PycObject> obj) const override;
 
-    void load(class PycData* stream, class PycModule* mod) override;
+    void load(class PycData* stream, class PycModule* mod, int currentDepth, int maxDepth) override;
 
     const char* value() const { return m_value.c_str(); }
 
@@ -66,7 +66,7 @@ public:
 
     bool isEqual(PycRef<PycObject> obj) const override;
 
-    void load(class PycData* stream, class PycModule* mod) override;
+    void load(class PycData* stream, class PycModule* mod, int currentDepth, int maxDepth) override;
 
     const char* imag() const { return m_imag.c_str(); }
 
@@ -85,7 +85,7 @@ public:
                (m_value == obj.cast<PycCFloat>()->m_value);
     }
 
-    void load(class PycData* stream, class PycModule* mod) override;
+    void load(class PycData* stream, class PycModule* mod, int currentDepth, int maxDepth) override;
 
     double value() const { return m_value; }
 
@@ -104,7 +104,7 @@ public:
                (m_imag == obj.cast<PycCComplex>()->m_imag);
     }
 
-    void load(class PycData* stream, class PycModule* mod) override;
+    void load(class PycData* stream, class PycModule* mod, int currentDepth, int maxDepth) override;
 
     double imag() const { return m_imag; }
 

--- a/pyc_object.h
+++ b/pyc_object.h
@@ -139,7 +139,7 @@ public:
         return obj.isIdent(this);
     }
 
-    virtual void load(PycData*, PycModule*) { }
+    virtual void load(PycData*, PycModule*, int, int) { }
 
 private:
     int m_refs;
@@ -157,7 +157,8 @@ int PycRef<_Obj>::type() const
 }
 
 PycRef<PycObject> CreateObject(int type);
-PycRef<PycObject> LoadObject(PycData* stream, PycModule* mod);
+int CheckRecursionDepth(int currentDepth, int maxDepth);
+PycRef<PycObject> LoadObject(PycData* stream, PycModule* mod, int currentDepth, int maxDepth);
 
 /* Static Singleton objects */
 extern PycRef<PycObject> Pyc_None;

--- a/pyc_sequence.cpp
+++ b/pyc_sequence.cpp
@@ -4,16 +4,25 @@
 #include <stdexcept>
 
 /* PycTuple */
-void PycTuple::load(PycData* stream, PycModule* mod)
+void PycTuple::load(PycData* stream, PycModule* mod, int currentDepth, int maxDepth)
 {
-    if (type() == TYPE_SMALL_TUPLE)
-        m_size = stream->getByte();
-    else
-        m_size = stream->get32();
+	if (CheckRecursionDepth(currentDepth, maxDepth))
+	{
+		if (type() == TYPE_SMALL_TUPLE)
+		{
+			m_size = stream->getByte();
+		}
+		else
+		{
+			m_size = stream->get32();
+		}
 
-    m_values.resize(m_size);
-    for (int i=0; i<m_size; i++)
-        m_values[i] = LoadObject(stream, mod);
+		m_values.resize(m_size);
+		for (int i=0; i<m_size; i++)
+		{
+			m_values[i] = LoadObject(stream, mod, currentDepth + 1, maxDepth);
+		}
+	}
 }
 
 bool PycTuple::isEqual(PycRef<PycObject> obj) const
@@ -36,11 +45,14 @@ bool PycTuple::isEqual(PycRef<PycObject> obj) const
 
 
 /* PycList */
-void PycList::load(PycData* stream, PycModule* mod)
+void PycList::load(PycData* stream, PycModule* mod, int currentDepth, int maxDepth)
 {
-    m_size = stream->get32();
-    for (int i=0; i<m_size; i++)
-        m_values.push_back(LoadObject(stream, mod));
+	if (CheckRecursionDepth(currentDepth, maxDepth))
+	{
+		m_size = stream->get32();
+		for (int i=0; i<m_size; i++)
+			m_values.push_back(LoadObject(stream, mod, currentDepth + 1, maxDepth));
+	}
 }
 
 bool PycList::isEqual(PycRef<PycObject> obj) const
@@ -77,17 +89,20 @@ PycRef<PycObject> PycList::get(int idx) const
 
 
 /* PycDict */
-void PycDict::load(PycData* stream, PycModule* mod)
+void PycDict::load(PycData* stream, PycModule* mod, int currentDepth, int maxDepth)
 {
-    PycRef<PycObject> key, val;
-    for (;;) {
-        key = LoadObject(stream, mod);
-        if (key == NULL)
-            break;
-        val = LoadObject(stream, mod);
-        m_keys.push_back(key);
-        m_values.push_back(val);
-    }
+	if (CheckRecursionDepth(currentDepth, maxDepth))
+	{
+		PycRef<PycObject> key, val;
+		for (;;) {
+			key = LoadObject(stream, mod, currentDepth + 1, maxDepth);
+			if (key == NULL)
+				break;
+			val = LoadObject(stream, mod, currentDepth + 1, maxDepth);
+			m_keys.push_back(key);
+			m_values.push_back(val);
+		}
+	}
 }
 
 bool PycDict::isEqual(PycRef<PycObject> obj) const
@@ -144,11 +159,16 @@ PycRef<PycObject> PycDict::get(int idx) const
 
 
 /* PycSet */
-void PycSet::load(PycData* stream, PycModule* mod)
+void PycSet::load(PycData* stream, PycModule* mod, int currentDepth, int maxDepth)
 {
-    m_size = stream->get32();
-    for (int i=0; i<m_size; i++)
-        m_values.insert(LoadObject(stream, mod));
+	if (CheckRecursionDepth(currentDepth, maxDepth))
+	{
+		m_size = stream->get32();
+		for (int i=0; i<m_size; i++)
+		{
+			m_values.insert(LoadObject(stream, mod, currentDepth + 1, maxDepth));
+		}
+	}
 }
 
 bool PycSet::isEqual(PycRef<PycObject> obj) const

--- a/pyc_sequence.h
+++ b/pyc_sequence.h
@@ -25,7 +25,7 @@ public:
 
     bool isEqual(PycRef<PycObject> obj) const override;
 
-    void load(class PycData* stream, class PycModule* mod) override;
+    void load(class PycData* stream, class PycModule* mod, int currentDepth, int maxDepth) override;
 
     const value_t& values() const { return m_values; }
     PycRef<PycObject> get(int idx) const override { return m_values.at(idx); }
@@ -42,7 +42,7 @@ public:
 
     bool isEqual(PycRef<PycObject> obj) const override;
 
-    void load(class PycData* stream, class PycModule* mod) override;
+    void load(class PycData* stream, class PycModule* mod, int currentDepth, int maxDepth) override;
 
     const value_t& values() const { return m_values; }
     PycRef<PycObject> get(int idx) const override;
@@ -60,7 +60,7 @@ public:
 
     bool isEqual(PycRef<PycObject> obj) const override;
 
-    void load(class PycData* stream, class PycModule* mod) override;
+    void load(class PycData* stream, class PycModule* mod, int currentDepth, int maxDepth) override;
 
     PycRef<PycObject> get(PycRef<PycObject> key) const;
     const key_t& keys() const { return m_keys; }
@@ -81,7 +81,7 @@ public:
 
     bool isEqual(PycRef<PycObject> obj) const override;
 
-    void load(class PycData* stream, class PycModule* mod) override;
+    void load(class PycData* stream, class PycModule* mod, int currentDepth, int maxDepth) override;
 
     const value_t& values() const { return m_values; }
     PycRef<PycObject> get(int idx) const override;

--- a/pyc_string.h
+++ b/pyc_string.h
@@ -19,7 +19,7 @@ public:
         return m_value.substr(0, str.size()) == str;
     }
 
-    void load(class PycData* stream, class PycModule* mod) override;
+    void load(class PycData* stream, class PycModule* mod, int currentDepth, int maxDepth) override;
 
     int length() const { return (int)m_value.size(); }
     const char* value() const { return m_value.c_str(); }


### PR DESCRIPTION
Decompyle++ is an amazing tool, but it will sometimes get stuck in infinite recursion loops until the system runs out of memory.

I've added recursion-limiting on both object loading and source code generation to work around this issue when analyzing problematic code. It defaults to 100 levels (probably more than enough for any real-world code), but can be changed with the new -m command-line option.

This doesn't fix the underlying issue that causes a particular infinite recursion, but it usually allows partial decompilation of the problem code. More importantly, if Decompyle++ is being used in a batch script, explicitly failing a single run of the tool and then proceeding to the next file is preferable to the entire script failing in the middle when one problem file causes infinite recursion.