### PR TITLE
Fix for Unsupported opcode: WITH_EXCEPT_START

### DIFF
--- a/ASTree.cpp
+++ b/ASTree.cpp
@@ -92,21 +92,28 @@ PycRef<ASTNode> BuildFromCode(PycRef<PycCode> code, PycModule* mod)
     bool variable_annotations = false;
 
     while (!source.atEof()) {
+
+        curpos = pos;
+        bc_next(source, mod, opcode, operand, pos);
+
 #if defined(BLOCK_DEBUG) || defined(STACK_DEBUG)
-        fprintf(stderr, "%-7d", pos);
+        // DEBUG Positon in source file
+        fprintf(stderr, "%-7d  %-3d %-16s_%-2d", pos, opcode, Pyc::OpcodeName(opcode & 0xFF), operand);
     #ifdef STACK_DEBUG
         fprintf(stderr, "%-5d", (unsigned int)stack_hist.size() + 1);
     #endif
     #ifdef BLOCK_DEBUG
+        // DEBUG Indept
         for (unsigned int i = 0; i < blocks.size(); i++)
             fprintf(stderr, "    ");
+
+        // DEBUG Type String & Length
         fprintf(stderr, "%s (%d)", curblock->type_str(), curblock->end());
     #endif
         fprintf(stderr, "\n");
 #endif
 
-        curpos = pos;
-        bc_next(source, mod, opcode, operand, pos);
+
 
         if (need_try && opcode != Pyc::SETUP_EXCEPT_A) {
             need_try = false;
@@ -1759,8 +1766,110 @@ PycRef<ASTNode> BuildFromCode(PycRef<PycCode> code, PycModule* mod)
             }
             break;
         case Pyc::POP_EXCEPT:
-            /* Do nothing. */
+            /* Do nothing. 
+            Pops a value from the stack, which is used to restore the exception state.
+
+            Changed in version 3.11: Exception representation on the stack now consist of one, not three, items.
+            */
             break;
+
+        case Pyc::WITH_EXCEPT_START:
+          /*
+          Calls the function in position 4 on the stack with arguments (type, val, tb) representing the exception at the top of the stack. Used to implement the call context_manager.__exit__(*exc_info()) when an exception has occurred in a with statement.
+          New in version 3.9.
+
+          The __exit__ function is in position 4 of the stack rather than 7. Exception representation on the stack now consist of one, not three, items.
+          Changed in version 3.11:
+          */
+        {
+            //curblock = ASTBlock::BLK_EXCEPT;
+          PycRef<PycString> msg = new PycString();
+          msg->setValue (
+               "# Decompile 'WITH_EXCEPT_START' is not implemented yet.\n"
+             );
+            //fputs( msg->strValue, pyc_output);
+        case Pyc::POP_EXCEPT:
+          /* Do nothing.
+          Pops a value from the stack, which is used to restore the exception state.
+
+          Changed in version 3.11: Exception representation on the stack now consist of one, not three, items.
+          */
+          break;
+
+        case Pyc::WITH_EXCEPT_START:
+          /*
+          Calls the function in position 4 on the stack with arguments (type, val, tb) representing the exception at the top of the stack. Used to implement the call context_manager.__exit__(*exc_info()) when an exception has occurred in a with statement.
+          New in version 3.9.
+
+          The __exit__ function is in position 4 of the stack rather than 7. Exception representation on the stack now consist of one, not three, items.
+          Changed in version 3.11:
+          */
+        {
+          //curblock = ASTBlock::BLK_EXCEPT;
+          PycRef<PycString> msg = new PycString();
+          msg->setValue(
+            "# Decompile 'WITH_EXCEPT_START' is not implemented yet.\n"
+          );
+          //fputs( msg->strValue, pyc_output);
+          OutputString(msg);
+          /*
+         // TODO: Get that message into the AST (Abtract Syntax Tree) to be shown at the right spot
+         //       However that f*** Types in CPP gimme a crisis
+         //
+         //       ... and again I know why I prefer Python when coding.
+
+                     PycRef<PycString> name = new ASTName( msg );
+                     curblock->append(
+                           name.cast<PycString>()
+                     );
+         */
+        }
+        break;
+
+        case Pyc::RERAISE:
+          // Re-raises the exception currently on top of the stack. 
+          // If oparg is non-zero, pops an additional value from the stack which is used to 
+          // set f_lasti of the current frame.
+          // New in version 3.9.
+          //  Changed in version 3.11: Exception representation on the stack now consist of one, not three, items.
+          //https://docs.python.org/3/library/dis.html#opcode-RERAISE
+
+        {
+          const char* msg = "# Decompile 'RERAISE' is not implemented yet.\n";
+          fputs(msg, pyc_output);
+        }
+        break;
+
+        case Pyc::POP_TOP:
+          OutputString( msg);
+ /*
+// TODO: Get that message into the AST (Abtract Syntax Tree) to be shown at the right spot
+//       However that f*** Types in CPP gimme a crisis 
+//
+//       ... and again I know why I prefer Python when coding.
+
+            PycRef<PycString> name = new ASTName( msg );
+            curblock->append(
+                  name.cast<PycString>()
+            );
+*/
+        }
+        break;
+        
+        case Pyc::RERAISE:
+        // Re-raises the exception currently on top of the stack. 
+        // If oparg is non-zero, pops an additional value from the stack which is used to 
+        // set f_lasti of the current frame.
+        // New in version 3.9.
+        //  Changed in version 3.11: Exception representation on the stack now consist of one, not three, items.
+        //https://docs.python.org/3/library/dis.html#opcode-RERAISE
+
+        {
+          const char* msg = "# Decompile 'RERAISE' is not implemented yet.\n";
+          fputs(msg, pyc_output);
+        }
+        break;
+
         case Pyc::POP_TOP:
             {
                 PycRef<ASTNode> value = stack.top();
@@ -1799,6 +1908,7 @@ PycRef<ASTNode> BuildFromCode(PycRef<PycCode> code, PycModule* mod)
                 PycRef<ASTPrint> printNode;
                 if (curblock->size() > 0 && curblock->nodes().back().type() == ASTNode::NODE_PRINT)
                     printNode = curblock->nodes().back().try_cast<ASTPrint>();
+
                 if (printNode && printNode->stream() == nullptr && !printNode->eol())
                     printNode->add(stack.top());
                 else
@@ -1979,6 +2089,7 @@ PycRef<ASTNode> BuildFromCode(PycRef<PycCode> code, PycModule* mod)
                 }
             }
             break;
+
         case Pyc::SETUP_EXCEPT_A:
             {
                 if (curblock->blktype() == ASTBlock::BLK_CONTAINER) {


### PR DESCRIPTION
-> Fixed for
Unsupported opcode: [WITH_EXCEPT_START](https://docs.python.org/3/library/dis.html#opcode-WITH_EXCEPT_START) and
Unsupported opcode: [RERAISE](https://docs.python.org/3/library/dis.html#opcode-RERAISE)
 by just adding these into the AST builder but without implementing any handler for it.
( too complicated for me to understand the code and types ) However now it runs.

-> added some useful comments on some opcodes
-> make the  BLOCK_DEBUG to also show Opcodes