### PR TITLE
Fix the pointer's behavior on getting buffer from `PycBuffer`

### DIFF
--- a/data.cpp
+++ b/data.cpp
@@ -80,6 +80,7 @@ int PycBuffer::getBuffer(int bytes, void* buffer)
         bytes = m_size - m_pos;
     if (bytes != 0)
         memcpy(buffer, (m_buffer + m_pos), bytes);
+    m_pos += bytes;
     return bytes;
 }
 


### PR DESCRIPTION
This fixes `PycBuffer`'s behavior on `PycBuffer::getBuffer`, where a pointer increment is expected but the pointer keeps its original value.