### PR TITLE
Add support for 3.6+ default arguments

### DIFF
--- a/ASTree.cpp
+++ b/ASTree.cpp
@@ -1469,6 +1469,7 @@ PycRef<ASTNode> BuildFromCode(PycRef<PycCode> code, PycModule* mod)
             break;
         case Pyc::LOAD_CLOSURE_A:
             /* Ignore this */
+            stack.push(new ASTNode());
             break;
         case Pyc::LOAD_CONST_A:
             {


### PR DESCRIPTION
Fixes #138 and #155 

Python 3.6 moved from pushing the default arguments individually to the stack to pushing a tuple with them.

Modifications:
- [`LOAD_CLOSURE`](https://docs.python.org/3.6/library/dis.html#opcode-LOAD_CLOSURE) should push junk to the stack instead of skipping, as `MAKE_FUNCTION` with operand 8 will have a structure like follows:
```
 10           0 LOAD_CONST               4 (('',))
              2 LOAD_CLOSURE             0 (digestmod)
              4 BUILD_TUPLE              1
              6 LOAD_CONST               2 (<code object <lambda> at 0x5629f4e717a0, file "example.py", line 10>)
              8 LOAD_CONST               3 ('__init__.<locals>.<lambda>')
             10 MAKE_FUNCTION            9
```
- [`MAKE_FUNCTION`](https://docs.python.org/3.6/library/dis.html#opcode-MAKE_FUNCTION) will handle default arguments of type 1, 2 and 8 (4 is about type hints).