### PR TITLE
Fix CMP0148 warning in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if (ENABLE_STACK_DEBUG)
 endif()
 
 # For generating the bytes tables
-find_package(PythonInterp REQUIRED)
+find_package(Python REQUIRED)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wshadow -Werror ${CMAKE_CXX_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 project(pycdc)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -17,7 +17,7 @@ if (ENABLE_STACK_DEBUG)
 endif()
 
 # For generating the bytes tables
-find_package(Python REQUIRED)
+find_package(Python COMPONENTS Interpreter REQUIRED)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wshadow -Werror ${CMAKE_CXX_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ foreach(ver ${PYTHON_VERSIONS})
 endforeach()
 
 add_custom_command(OUTPUT ${MAP_SOURCES}
-                   COMMAND ${PYTHON_EXECUTABLE}
+                   COMMAND ${Python_EXECUTABLE}
                            ${CMAKE_CURRENT_SOURCE_DIR}/bytes/comp_map.py
                            ${CMAKE_CURRENT_SOURCE_DIR}/bytes
                            ${CMAKE_CURRENT_BINARY_DIR}/bytes


### PR DESCRIPTION
The purpose of this PR is to address the CMake warning, which is as follows:
```
CMake Warning (dev) at CMakeLists.txt:20 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

This warning is for project developers.  Use -Wno-dev to suppress it.
```

CMP0148 will remove ``FindPythonInterp`` and ``FindPythonLibs`` modules.
Projects using modules above should be updated to use one of their replacements:
* ``FindPython3``
* ``FindPython2``
* ``FindPython``
This policy was introduced in CMake version 3.27.

SEE: [CMP0148](https://cmake.org/cmake/help/latest/policy/CMP0148.html)