### PR TITLE
Gaurd against pop from empty block stack

### DIFF
--- a/ASTree.cpp
+++ b/ASTree.cpp
@@ -1306,6 +1306,12 @@ PycRef<ASTNode> BuildFromCode(PycRef<PycCode> code, PycModule* mod)
                     stack_hist.pop();
                 }
 
+                if (blocks.size() == 1 && !source.atEof()) {
+                    fprintf(stderr, "Warning: Refusing to pop last block when there is more code to parse pos: %d OP: %02x\n", pos, opcode & 0xff);
+                    cleanBuild = false;
+                    break;
+                }
+
                 PycRef<ASTBlock> prev = curblock;
                 PycRef<ASTBlock> nil;
                 bool push = true;
@@ -1587,6 +1593,12 @@ PycRef<ASTNode> BuildFromCode(PycRef<PycCode> code, PycModule* mod)
                 if (curblock->nodes().size() &&
                         curblock->nodes().back().type() == ASTNode::NODE_KEYWORD) {
                     curblock->removeLast();
+                }
+
+                if (blocks.size() == 1 && !source.atEof()) {
+                    fprintf(stderr, "Warning: Refusing to pop last block when there is more code to parse pos: %d OP: %02x\n", pos, opcode & 0xff);
+                    cleanBuild = false;
+                    break;
                 }
 
                 if (curblock->blktype() == ASTBlock::BLK_IF


### PR DESCRIPTION
I got a segfault when a block stack pop, when the block stack was already empty. This pull prevents emptying the block stack unless you are on the last instruction of the file. Or this is what I intended at least, I am new to this code base and pyc files in general.
 
This will prevent segfault seen in issue #387, I got a similar segfault independently. This pull prevents the segfault but the segfault would not occur if blocks were correctly parsed on a legitimate pyc file. So I don't know if this is really a fix for #387.