### PR TITLE
Fix Long Numeric Integer representation for Python 3

### DIFF
--- a/bytecode.cpp
+++ b/bytecode.cpp
@@ -230,7 +230,7 @@ void print_const(std::ostream& pyc_output, PycRef<PycObject> obj, PycModule* mod
         formatted_print(pyc_output, "%d", obj.cast<PycInt>()->value());
         break;
     case PycObject::TYPE_LONG:
-        formatted_print(pyc_output, "%s", obj.cast<PycLong>()->repr().c_str());
+        formatted_print(pyc_output, "%s", obj.cast<PycLong>()->repr(mod).c_str());
         break;
     case PycObject::TYPE_FLOAT:
         formatted_print(pyc_output, "%s", obj.cast<PycFloat>()->value());

--- a/pyc_numeric.cpp
+++ b/pyc_numeric.cpp
@@ -53,13 +53,13 @@ bool PycLong::isEqual(PycRef<PycObject> obj) const
     return true;
 }
 
-std::string PycLong::repr() const
+std::string PycLong::repr(PycModule* mod) const
 {
     // Longs are printed as hex, since it's easier (and faster) to convert
     // arbitrary-length integers to a power of two than an arbitrary base
 
     if (m_size == 0)
-        return "0x0L";
+        return (mod->verCompare(3, 0) >= 0) ? "0x0" : "0x0L";
 
     // Realign to 32 bits, since Python uses only 15
     std::vector<unsigned> bits;
@@ -90,7 +90,8 @@ std::string PycLong::repr() const
     aptr += snprintf(aptr, 9, "%X", *iter++);
     while (iter != bits.rend())
         aptr += snprintf(aptr, 9, "%08X", *iter++);
-    *aptr++ = 'L';
+    if (mod->verCompare(3, 0) < 0)
+        *aptr++ = 'L';
     *aptr = 0;
     return accum;
 }

--- a/pyc_numeric.h
+++ b/pyc_numeric.h
@@ -37,7 +37,7 @@ public:
     int size() const { return m_size; }
     const std::vector<int>& value() const { return m_value; }
 
-    std::string repr() const;
+    std::string repr(PycModule* mod) const;
 
 private:
     int m_size;

--- a/pycdas.cpp
+++ b/pycdas.cpp
@@ -223,7 +223,7 @@ void output_object(PycRef<PycObject> obj, PycModule* mod, int indent,
         iprintf(pyc_output, indent, "%d\n", obj.cast<PycInt>()->value());
         break;
     case PycObject::TYPE_LONG:
-        iprintf(pyc_output, indent, "%s\n", obj.cast<PycLong>()->repr().c_str());
+        iprintf(pyc_output, indent, "%s\n", obj.cast<PycLong>()->repr(mod).c_str());
         break;
     case PycObject::TYPE_FLOAT:
         iprintf(pyc_output, indent, "%s\n", obj.cast<PycFloat>()->value());


### PR DESCRIPTION
Before Python 3, long integers were input with an `L` suffix. Since Python 3, all integers are 64-bit and do not need the `L` suffix.
Source: https://docs.python.org/3.0/whatsnew/3.0.html#integers

Scripts generated by `pycdc` from Python 3 that contained long numeric integers would not work on Python 3 because it always suffixed them with `L`.

Note: I am not sure how to adapt the test suite to reflect this.
Should I just add the `.pyc` file without changing `test_integers.py` ? That file was made with Python 2 in mind (e.g. `print` without parenthesis).
EDIT: Nvm, there is too many differences (e.g. `sys.maxint` was removed in Python 3).