### PR TITLE
show INVALID opcode properly if < 0

### DIFF
--- a/ASTree.cpp
+++ b/ASTree.cpp
@@ -2474,7 +2474,7 @@ PycRef<ASTNode> BuildFromCode(PycRef<PycCode> code, PycModule* mod)
             }
             break;
         default:
-            fprintf(stderr, "Unsupported opcode: %s\n", Pyc::OpcodeName(opcode & 0xFF));
+            fprintf(stderr, "Unsupported opcode: %s (%d)\n", Pyc::OpcodeName(opcode), opcode);
             cleanBuild = false;
             return new ASTNodeList(defblock->nodes());
         }


### PR DESCRIPTION
When an opcode ends up < 0, not we send it to `Pyc::OpcodeName()` so it can report properly invalid