### PR TITLE
Support new type - PycObject::TYPE_SLICE

### DIFF
--- a/bytecode.cpp
+++ b/bytecode.cpp
@@ -271,6 +271,18 @@ void print_const(std::ostream& pyc_output, PycRef<PycObject> obj, PycModule* mod
     case PycObject::TYPE_CODE2:
         pyc_output << "<CODE> " << obj.cast<PycCode>()->name()->value();
         break;
+    case PycObject::TYPE_SLICE:
+    {
+        pyc_output << "slice(";
+        const auto slice = obj.cast<PycSlice>();
+        print_const(pyc_output, slice->get(0), mod);
+        pyc_output << ":";
+        print_const(pyc_output, slice->get(1), mod);
+        pyc_output << ":";
+        print_const(pyc_output, slice->get(2), mod);
+        pyc_output << ")";
+    }
+    break;
     default:
         formatted_print(pyc_output, "<TYPE: %d>\n", obj->type());
     }

--- a/pyc_object.cpp
+++ b/pyc_object.cpp
@@ -62,6 +62,8 @@ PycRef<PycObject> CreateObject(int type)
     case PycObject::TYPE_SET:
     case PycObject::TYPE_FROZENSET:
         return new PycSet(type);
+    case PycObject::TYPE_SLICE:
+        return new PycSlice;
     default:
         fprintf(stderr, "CreateObject: Got unsupported type 0x%X\n", type);
         return NULL;

--- a/pyc_object.h
+++ b/pyc_object.h
@@ -127,6 +127,7 @@ public:
         TYPE_SMALL_TUPLE = ')',             // Python 3.4 ->
         TYPE_SHORT_ASCII = 'z',             // Python 3.4 ->
         TYPE_SHORT_ASCII_INTERNED = 'Z',    // Python 3.4 ->
+        TYPE_SLICE = ':',                   // Python 3.14 ->
     };
 
     PycObject(int type = TYPE_UNKNOWN) : m_refs(0), m_type(type) { }

--- a/pyc_sequence.cpp
+++ b/pyc_sequence.cpp
@@ -78,3 +78,12 @@ bool PycDict::isEqual(PycRef<PycObject> obj) const
     }
     return true;
 }
+
+/* PycSlice */
+void PycSlice::load(PycData* stream, PycModule* mod)
+{
+	m_size = 3; // start, stop, step
+    m_values.reserve(m_size);
+    for (int i = 0; i < m_size; i++)
+        m_values.push_back(LoadObject(stream, mod));
+}

--- a/pyc_sequence.h
+++ b/pyc_sequence.h
@@ -70,4 +70,11 @@ private:
     value_t m_values;
 };
 
+class PycSlice : public PycSimpleSequence {
+public:
+    PycSlice() : PycSimpleSequence(TYPE_SLICE) {}
+
+    void load(class PycData* stream, class PycModule* mod) override;
+};
+
 #endif

--- a/pycdas.cpp
+++ b/pycdas.cpp
@@ -252,6 +252,18 @@ void output_object(PycRef<PycObject> obj, PycModule* mod, int indent,
         iprintf(pyc_output, indent, "(%g+%gj)\n", obj.cast<PycCComplex>()->value(),
                                       obj.cast<PycCComplex>()->imag());
         break;
+    case PycObject::TYPE_SLICE:
+        {
+            const auto slice = obj.cast<PycSlice>();
+            iputs(pyc_output, indent, "slice(");
+            output_object(slice->get(0), mod, 0, flags, pyc_output);
+            iprintf(pyc_output, 0, ":");
+            output_object(slice->get(1), mod, 0, flags, pyc_output);
+            iprintf(pyc_output, 0, ":");
+            output_object(slice->get(2), mod, 0, flags, pyc_output);
+            iputs(pyc_output, indent, ")\n");
+        }
+        break;
     default:
         iprintf(pyc_output, indent, "<TYPE: %d>\n", obj->type());
     }


### PR DESCRIPTION
When [3.14 support](https://github.com/zrax/pycdc/pull/566) is merged, this will also be needed to load PYC files at all (at least for `pycdas`).

By the way, when merging 3.14 support, use final/proper 3.14 magic number:
`    MAGIC_3_14 = 0x0A0D0E2B,`